### PR TITLE
Changed the .NET Core installation channel

### DIFF
--- a/build/Autofac.Build.psm1
+++ b/build/Autofac.Build.psm1
@@ -47,7 +47,7 @@ function Install-DotNetCli
   }
 
   # Run the dotnet CLI install
-  & .\.dotnet\dotnet-install.ps1
+  & .\.dotnet\dotnet-install.ps1 -Channel Current
 
   # Add the dotnet folder path to the process.
   Remove-EnvironmentPathEntry $env:DOTNET_INSTALL_DIR

--- a/test/Autofac.Extras.MvvmCross.Test/AutofacMvxIocProviderFixture.cs
+++ b/test/Autofac.Extras.MvvmCross.Test/AutofacMvxIocProviderFixture.cs
@@ -272,7 +272,7 @@ namespace Autofac.Extras.MvvmCross.Test
             Mvx.RegisterType<IInterface2, Concrete2>();
 
             // Act
-            var obj = Mvx.IocConstruct<HasDependantProperty>();
+            var obj = Mvx.IoCProvider.IoCConstruct<HasDependantProperty>();
 
             // Assert
             Assert.NotNull(obj);
@@ -293,7 +293,7 @@ namespace Autofac.Extras.MvvmCross.Test
             Mvx.RegisterType<IInterface2, Concrete2>();
 
             // Act
-            var obj = Mvx.IocConstruct<HasDependantProperty>();
+            var obj = Mvx.IoCProvider.IoCConstruct<HasDependantProperty>();
 
             // Assert
             Assert.NotNull(obj);
@@ -312,7 +312,7 @@ namespace Autofac.Extras.MvvmCross.Test
                 });
             Mvx.RegisterType<IInterface1, Concrete1>();
             Mvx.RegisterType<IInterface2, Concrete2>();
-            Mvx.RegisterSingleton<IHasDependantProperty>(Mvx.IocConstruct<HasDependantProperty>);
+            Mvx.RegisterSingleton<IHasDependantProperty>(Mvx.IoCProvider.IoCConstruct<HasDependantProperty>);
 
             // Act
             var obj = Mvx.Resolve<IHasDependantProperty>();
@@ -336,7 +336,7 @@ namespace Autofac.Extras.MvvmCross.Test
             Mvx.RegisterType<IInterface2, Concrete2>();
 
             // Act
-            var obj = Mvx.IocConstruct<HasDependantProperty>();
+            var obj = Mvx.IoCProvider.IoCConstruct<HasDependantProperty>();
 
             // Assert
             Assert.NotNull(obj);
@@ -355,7 +355,7 @@ namespace Autofac.Extras.MvvmCross.Test
             });
             Mvx.RegisterType<IInterface1, Concrete1>();
             Mvx.RegisterType<IInterface2, Concrete2>();
-            Mvx.RegisterSingleton<IHasDependantProperty>(Mvx.IocConstruct<HasDependantProperty>);
+            Mvx.RegisterSingleton<IHasDependantProperty>(Mvx.IoCProvider.IoCConstruct<HasDependantProperty>);
 
             // Act
             var obj = Mvx.Resolve<IHasDependantProperty>();
@@ -377,7 +377,7 @@ namespace Autofac.Extras.MvvmCross.Test
                 });
 
             // Act
-            var obj = Mvx.IocConstruct<HasDependantProperty>();
+            var obj = Mvx.IoCProvider.IoCConstruct<HasDependantProperty>();
 
             // Assert
             Assert.NotNull(obj);


### PR DESCRIPTION
Added the -Channel Current switch to .NET Core installation script to install the latest version instead of LTS (currently 1.1).